### PR TITLE
chore: get GTest with FetchContent

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ You do not need to install these by hand, they will be pulled by CMake during co
 
 ### For the tests
 
-- [Google Test](https://github.com/google/googletest) (manual install)
+- [Google Test](https://github.com/google/googletest) (will be automatically pulled during configuration)
 - [Google Benchmark](https://github.com/google/benchmark) (included as git submodule, will be pulled by CMake during configuration if building benchmarks is enabled)
 
 ### For the documentation

--- a/ci/install-osx.sh
+++ b/ci/install-osx.sh
@@ -4,11 +4,11 @@
 pip3 install jinja2 Pygments
 
 # clone, compile and make Google test
-git clone https://github.com/google/googletest.git ./external/gtest
-cd ./external/gtest
-git checkout tags/release-1.10.0
-mkdir build
-cd build
-cmake -Dgtest_build_samples=OFF -Dgtest_build_tests=OFF ../
-make
-make install
+# git clone https://github.com/google/googletest.git ./external/gtest
+# cd ./external/gtest
+# git checkout tags/release-1.10.0
+# mkdir build
+# cd build
+# cmake -Dgtest_build_samples=OFF -Dgtest_build_tests=OFF ../
+# make
+# make install

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,15 +64,18 @@ target_include_directories(${target}
 # Libraries
 #
 
-include(GoogleTest)
-set(GTEST_ROOT "/usr/local/include/gtest" CACHE PATH "Path to googletest")
-find_package(GTest REQUIRED)
+# Get GTest
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        master
+)
+FetchContent_MakeAvailable(googletest)
 
 target_link_libraries(${target}
     PRIVATE
-    # ${DEFAULT_LIBRARIES}
     ${PROJECT_NAME}::${PROJECT_NAME}
-    GTest::GTest
+    gtest
 )
 
 


### PR DESCRIPTION
GTest used to be required as a global install, now it's pulled in with CMake's FetchContent.