### PR TITLE
chore: copy CNAME into html root directory for doc deployment

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -46,6 +46,10 @@ jobs:
       - name: build documentation
         run: |
             sh ./ci/github/build-documentation-unix.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: doc
+          path: doc/html/
       - name: deploy documentation
         # only deploy on pushes to master
         if: steps.extract_branch.outputs.branch == 'master'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # spice-lib. An image processing library.
 
-[![Build Status](https://travis-ci.com/JanHett/spice-lib.svg?branch=master)](https://travis-ci.com/JanHett/spice-lib) [![Lines of Code](https://tokei.rs/b1/github/JanHett/spice-lib)](https://github.com/XAMPPRocky/tokei)
+[![Lines of Code](https://tokei.rs/b1/github/JanHett/spice-lib)](https://github.com/XAMPPRocky/tokei)
 
 ## Support and status
 

--- a/ci/github/build-documentation-unix.sh
+++ b/ci/github/build-documentation-unix.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# build the doc
 cd build
-
 cmake --build . --config Release --target doc
+
+# copy CNAME file to deployed directory
+cd ../doc
+cp CNAME html

--- a/ci/github/install-for-documentation-linux.sh
+++ b/ci/github/install-for-documentation-linux.sh
@@ -28,4 +28,4 @@ sudo $HOME/bin/tlmgr install carlisle
 sudo $HOME/bin/tlmgr install collection-fontsrecommended
 # sudo $HOME/bin/tlmgr install collection-fontsextra # probably not needed
 
-sudo $PACKAGE_MANAGER install -y doxygen
+brew install doxygen

--- a/doc/CNAME
+++ b/doc/CNAME
@@ -1,0 +1,1 @@
+spice-lib.brotzeit.engineering

--- a/include/spice-lib/color_view.hpp
+++ b/include/spice-lib/color_view.hpp
@@ -1,8 +1,20 @@
+/**
+ * \file color_view.hpp
+ * \author Jan Hettenkofer (jan@hettenkofer.net)
+ * \brief Defines a non-owning view over data representing a color
+ * \version 0.1
+ * \date 2020-12-13
+ * 
+ * @copyright Copyright (c) 2020
+ * 
+ */
+
 #ifndef SPICE_COLOR_VIEW
 #define SPICE_COLOR_VIEW
 
 #include <type_traits>
 
+namespace spice {
 /**
  * \brief Wrapper around color data of arbitrary length with arbitrary stride
  * between channel samples
@@ -657,6 +669,8 @@ std::ostream& operator<<(std::ostream& os, color_view<T> const & pxl)
     os << pxl[pxl.size() - 1];
     os << ")";
     return os;
+}
+
 }
 
 #endif // SPICE_COLOR_VIEW


### PR DESCRIPTION
Since the doc is now published under a custom domain we need a CNAME file in the root of the published doc.

Also: upload doc as artefact as part of CI pipeline